### PR TITLE
Externally owned container is no longer disposed

### DIFF
--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/ContainerDecorator.cs
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/ContainerDecorator.cs
@@ -1,0 +1,294 @@
+﻿namespace NServiceBus.CastleWindsor.AcceptanceTests
+{
+    using System;
+    using System.Collections;
+    using Castle.Core;
+    using Castle.MicroKernel;
+    using Castle.MicroKernel.Registration;
+    using Castle.Windsor;
+
+    class ContainerDecorator : IWindsorContainer
+    {
+        IWindsorContainer decorated;
+
+        public ContainerDecorator(IWindsorContainer decorated)
+        {
+            this.decorated = decorated;
+        }
+
+        public void Dispose()
+        {
+            decorated.Dispose();
+            Disposed = true;
+        }
+
+        public bool Disposed { get; private set; }
+
+        public void AddChildContainer(IWindsorContainer childContainer)
+        {
+        }
+
+        public IWindsorContainer AddFacility(IFacility facility)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddFacility<TFacility>() where TFacility : IFacility, new()
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddFacility<TFacility>(Action<TFacility> onCreate) where TFacility : IFacility, new()
+        {
+            return null;
+        }
+
+        public IWindsorContainer GetChildContainer(string name)
+        {
+            return null;
+        }
+
+        public IWindsorContainer Install(params IWindsorInstaller[] installers)
+        {
+            return null;
+        }
+
+        public IWindsorContainer Register(params IRegistration[] registrations)
+        {
+            return null;
+        }
+
+        public void Release(object instance)
+        {
+        }
+
+        public void RemoveChildContainer(IWindsorContainer childContainer)
+        {
+        }
+
+        public object Resolve(string key, Type service)
+        {
+            return null;
+        }
+
+        public object Resolve(Type service)
+        {
+            return null;
+        }
+
+        public object Resolve(Type service, IDictionary arguments)
+        {
+            return null;
+        }
+
+        public object Resolve(Type service, object argumentsAsAnonymousType)
+        {
+            return null;
+        }
+
+        public T Resolve<T>()
+        {
+            return default(T);
+        }
+
+        public T Resolve<T>(IDictionary arguments)
+        {
+            return default(T);
+        }
+
+        public T Resolve<T>(object argumentsAsAnonymousType)
+        {
+            return default(T);
+        }
+
+        public T Resolve<T>(string key)
+        {
+            return default(T);
+        }
+
+        public T Resolve<T>(string key, IDictionary arguments)
+        {
+            return default(T);
+        }
+
+        public T Resolve<T>(string key, object argumentsAsAnonymousType)
+        {
+            return default(T);
+        }
+
+        public object Resolve(string key, Type service, IDictionary arguments)
+        {
+            return null;
+        }
+
+        public object Resolve(string key, Type service, object argumentsAsAnonymousType)
+        {
+            return null;
+        }
+
+        public T[] ResolveAll<T>()
+        {
+            return new T[]
+            {
+            };
+        }
+
+        public Array ResolveAll(Type service)
+        {
+            return null;
+        }
+
+        public Array ResolveAll(Type service, IDictionary arguments)
+        {
+            return null;
+        }
+
+        public Array ResolveAll(Type service, object argumentsAsAnonymousType)
+        {
+            return null;
+        }
+
+        public T[] ResolveAll<T>(IDictionary arguments)
+        {
+            return new T[]
+            {
+            };
+        }
+
+        public T[] ResolveAll<T>(object argumentsAsAnonymousType)
+        {
+            return new T[]
+            {
+            };
+        }
+
+        public IWindsorContainer AddComponent(string key, Type classType)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponent(string key, Type serviceType, Type classType)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponent<T>()
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponent<T>(string key)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponent<I, T>() where T : class
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponent<I, T>(string key) where T : class
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentLifeStyle(string key, Type classType, LifestyleType lifestyle)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentLifeStyle(string key, Type serviceType, Type classType, LifestyleType lifestyle)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentLifeStyle<T>(LifestyleType lifestyle)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentLifeStyle<T>(string key, LifestyleType lifestyle)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentLifeStyle<I, T>(LifestyleType lifestyle) where T : class
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentLifeStyle<I, T>(string key, LifestyleType lifestyle) where T : class
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentProperties<I, T>(IDictionary extendedProperties) where T : class
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentProperties<I, T>(string key, IDictionary extendedProperties) where T : class
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentWithProperties(string key, Type classType, IDictionary extendedProperties)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentWithProperties(string key, Type serviceType, Type classType, IDictionary extendedProperties)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentWithProperties<T>(IDictionary extendedProperties)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentWithProperties<T>(string key, IDictionary extendedProperties)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddFacility(string idInConfiguration, IFacility facility)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddFacility<TFacility>(string idInConfiguration) where TFacility : IFacility, new()
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddFacility<TFacility>(string idInConfiguration, Action<TFacility> configureFacility) where TFacility : IFacility, new()
+        {
+            return null;
+        }
+
+        public object Resolve(string key, IDictionary arguments)
+        {
+            return null;
+        }
+
+        public object Resolve(string key, object argumentsAsAnonymousType)
+        {
+            return null;
+        }
+
+        public IKernel Kernel { get; }
+        public string Name { get; }
+        public IWindsorContainer Parent { get; set; }
+
+        object IWindsorContainer.this[string key]
+        {
+            get { return null; }
+        }
+
+        object IWindsorContainer.this[Type service]
+        {
+            get { return null; }
+        }
+    }
+}

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
@@ -31,6 +31,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Castle.Windsor, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Windsor.3.3.0\lib\net45\Castle.Windsor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.6.0.0-rc0001\lib\net452\NServiceBus.AcceptanceTesting.dll</HintPath>
       <Private>True</Private>
@@ -39,8 +47,8 @@
       <HintPath>..\packages\NServiceBus.6.0.0-rc0001\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -48,6 +56,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Messaging" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.CastleWindsor\NServiceBus.CastleWindsor.csproj">
@@ -56,10 +65,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContainerDecorator.cs" />
     <Compile Include="DefaultServer.cs" />
     <Compile Include="NServiceBusAcceptanceTest.cs" />
     <Compile Include="When_declaring_a_public_property.cs" />
     <Compile Include="When_setting_properties_explicitly_via_the_container.cs" />
+    <Compile Include="When_using_externally_owned_container.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/When_using_externally_owned_container.cs
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/When_using_externally_owned_container.cs
@@ -1,0 +1,49 @@
+﻿namespace NServiceBus.CastleWindsor.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using Castle.Windsor;
+    using NServiceBus;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_externally_owned_container : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_shutdown_properly()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsFalse(context.Decorator.Disposed);
+            Assert.DoesNotThrow(() => context.Container.Dispose());
+        }
+
+        class Context : ScenarioContext
+        {
+            public IWindsorContainer Container { get; set; }
+            public ContainerDecorator Decorator { get; set; }
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((config, desc) =>
+                {
+                    var container = new WindsorContainer();
+                    var decorator = new ContainerDecorator(container);
+
+                    config.UseContainer<WindsorBuilder>(c => c.ExistingContainer(container));
+
+                    var context = (Context)desc.ScenarioContext;
+                    context.Container = container;
+                    context.Decorator = decorator;
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/packages.config
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Castle.Windsor" version="3.3.0" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTesting" version="6.0.0-rc0001" targetFramework="net452" />
-  <package id="NUnit" version="3.2.1" targetFramework="net452" />
+  <package id="NUnit" version="3.4.1" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.CastleWindsor.Tests/DisposalTests.cs
+++ b/src/NServiceBus.CastleWindsor.Tests/DisposalTests.cs
@@ -1,0 +1,314 @@
+﻿namespace NServiceBus.CastleWindsor.Tests
+{
+    using System;
+    using System.Collections;
+    using Castle.Core;
+    using Castle.MicroKernel;
+    using Castle.MicroKernel.Registration;
+    using Castle.Windsor;
+    using NUnit.Framework;
+    using ObjectBuilder.CastleWindsor;
+
+    [TestFixture]
+    public class DisposalTests
+    {
+        [Test]
+        public void Owned_container_should_be_disposed()
+        {
+            var fakeContainer = new FakeContainer();
+
+            var container = new WindsorObjectBuilder(fakeContainer, true);
+            container.Dispose();
+
+            Assert.True(fakeContainer.Disposed);
+        }
+
+        [Test]
+        public void Externally_owned_container_should_not_be_disposed()
+        {
+            var fakeContainer = new FakeContainer();
+
+            var container = new WindsorObjectBuilder(fakeContainer, false);
+            container.Dispose();
+
+            Assert.False(fakeContainer.Disposed);
+        }
+
+        class FakeContainer : IWindsorContainer
+        {
+            public bool Disposed { get; private set; }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+
+            public void AddChildContainer(IWindsorContainer childContainer)
+            {
+            }
+
+            public IWindsorContainer AddFacility(IFacility facility)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddFacility<TFacility>() where TFacility : IFacility, new()
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddFacility<TFacility>(Action<TFacility> onCreate) where TFacility : IFacility, new()
+            {
+                return null;
+            }
+
+            public IWindsorContainer GetChildContainer(string name)
+            {
+                return null;
+            }
+
+            public IWindsorContainer Install(params IWindsorInstaller[] installers)
+            {
+                return null;
+            }
+
+            public IWindsorContainer Register(params IRegistration[] registrations)
+            {
+                return null;
+            }
+
+            public void Release(object instance)
+            {
+            }
+
+            public void RemoveChildContainer(IWindsorContainer childContainer)
+            {
+            }
+
+            public object Resolve(string key, Type service)
+            {
+                return null;
+            }
+
+            public object Resolve(Type service)
+            {
+                return null;
+            }
+
+            public object Resolve(Type service, IDictionary arguments)
+            {
+                return null;
+            }
+
+            public object Resolve(Type service, object argumentsAsAnonymousType)
+            {
+                return null;
+            }
+
+            public T Resolve<T>()
+            {
+                return default(T);
+            }
+
+            public T Resolve<T>(IDictionary arguments)
+            {
+                return default(T);
+            }
+
+            public T Resolve<T>(object argumentsAsAnonymousType)
+            {
+                return default(T);
+            }
+
+            public T Resolve<T>(string key)
+            {
+                return default(T);
+            }
+
+            public T Resolve<T>(string key, IDictionary arguments)
+            {
+                return default(T);
+            }
+
+            public T Resolve<T>(string key, object argumentsAsAnonymousType)
+            {
+                return default(T);
+            }
+
+            public object Resolve(string key, Type service, IDictionary arguments)
+            {
+                return null;
+            }
+
+            public object Resolve(string key, Type service, object argumentsAsAnonymousType)
+            {
+                return null;
+            }
+
+            public T[] ResolveAll<T>()
+            {
+                return new T[]
+                {
+                };
+            }
+
+            public Array ResolveAll(Type service)
+            {
+                return null;
+            }
+
+            public Array ResolveAll(Type service, IDictionary arguments)
+            {
+                return null;
+            }
+
+            public Array ResolveAll(Type service, object argumentsAsAnonymousType)
+            {
+                return null;
+            }
+
+            public T[] ResolveAll<T>(IDictionary arguments)
+            {
+                return new T[]
+                {
+                };
+            }
+
+            public T[] ResolveAll<T>(object argumentsAsAnonymousType)
+            {
+                return new T[]
+                {
+                };
+            }
+
+            public IWindsorContainer AddComponent(string key, Type classType)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponent(string key, Type serviceType, Type classType)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponent<T>()
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponent<T>(string key)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponent<I, T>() where T : class
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponent<I, T>(string key) where T : class
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentLifeStyle(string key, Type classType, LifestyleType lifestyle)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentLifeStyle(string key, Type serviceType, Type classType, LifestyleType lifestyle)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentLifeStyle<T>(LifestyleType lifestyle)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentLifeStyle<T>(string key, LifestyleType lifestyle)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentLifeStyle<I, T>(LifestyleType lifestyle) where T : class
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentLifeStyle<I, T>(string key, LifestyleType lifestyle) where T : class
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentProperties<I, T>(IDictionary extendedProperties) where T : class
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentProperties<I, T>(string key, IDictionary extendedProperties) where T : class
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentWithProperties(string key, Type classType, IDictionary extendedProperties)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentWithProperties(string key, Type serviceType, Type classType, IDictionary extendedProperties)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentWithProperties<T>(IDictionary extendedProperties)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentWithProperties<T>(string key, IDictionary extendedProperties)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddFacility(string idInConfiguration, IFacility facility)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddFacility<TFacility>(string idInConfiguration) where TFacility : IFacility, new()
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddFacility<TFacility>(string idInConfiguration, Action<TFacility> configureFacility) where TFacility : IFacility, new()
+            {
+                return null;
+            }
+
+            public object Resolve(string key, IDictionary arguments)
+            {
+                return null;
+            }
+
+            public object Resolve(string key, object argumentsAsAnonymousType)
+            {
+                return null;
+            }
+
+            public IKernel Kernel { get; }
+            public string Name { get; }
+            public IWindsorContainer Parent { get; set; }
+
+            object IWindsorContainer.this[string key]
+            {
+                get { return null; }
+            }
+
+            object IWindsorContainer.this[Type service]
+            {
+                get { return null; }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
+++ b/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_querying_for_registered_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_registering_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_using_nested_containers.cs" />
+    <Compile Include="DisposalTests.cs" />
     <Compile Include="SetUpFixture.cs" />
     <Compile Include="When_base_type_is_registered.cs" />
   </ItemGroup>

--- a/src/NServiceBus.CastleWindsor/WindsorBuilder.cs
+++ b/src/NServiceBus.CastleWindsor/WindsorBuilder.cs
@@ -17,15 +17,25 @@
         /// <returns>The new container wrapper.</returns>
         public override ObjectBuilder.Common.IContainer CreateContainer(ReadOnlySettings settings)
         {
-            IWindsorContainer existingContainer;
+            ContainerHolder containerHolder;
 
-            if (settings.TryGet("ExistingContainer", out existingContainer))
+            if (settings.TryGet(out containerHolder))
             {
-                return new WindsorObjectBuilder(existingContainer);
+                return new WindsorObjectBuilder(containerHolder.ExistingContainer);
 
             }
 
             return new WindsorObjectBuilder();
+        }
+
+        internal class ContainerHolder
+        {
+            public ContainerHolder(IWindsorContainer container)
+            {
+                ExistingContainer = container;
+            }
+
+            public IWindsorContainer ExistingContainer { get; }
         }
     }
 }

--- a/src/NServiceBus.CastleWindsor/WindsorExtensions.cs
+++ b/src/NServiceBus.CastleWindsor/WindsorExtensions.cs
@@ -15,7 +15,7 @@
         /// <param name="container">The existing container instance.</param>
         public static void ExistingContainer(this ContainerCustomizations customizations, IWindsorContainer container)
         {
-            customizations.Settings.Set("ExistingContainer", container);
+            customizations.Settings.Set<WindsorBuilder.ContainerHolder>(new WindsorBuilder.ContainerHolder(container));
         }
     }
 }

--- a/src/NServiceBus.CastleWindsor/WindsorObjectBuilder.cs
+++ b/src/NServiceBus.CastleWindsor/WindsorObjectBuilder.cs
@@ -12,17 +12,22 @@
 
     class WindsorObjectBuilder : IContainer
     {
-        public WindsorObjectBuilder() : this(new WindsorContainer())
+        public WindsorObjectBuilder() : this(new WindsorContainer(), true)
         {
         }
 
-        public WindsorObjectBuilder(IWindsorContainer container)
+        public WindsorObjectBuilder(IWindsorContainer container) : this(container, false)
+        {
+        }
+
+        public WindsorObjectBuilder(IWindsorContainer container, bool owned)
         {
             if (container == null)
             {
                 throw new ArgumentNullException(nameof(container), "The object builder must be initialized with a valid windsor container");
             }
 
+            this.owned = owned;
             this.container = container;
             scope = container.BeginScope();
         }
@@ -124,7 +129,7 @@
             scope.Dispose();
 
             //if we are in a child scope dispose of that but not the parent container
-            if (!isChild)
+            if (!isChild && owned)
             {
                 container?.Dispose();
             }
@@ -164,5 +169,6 @@
         bool isChild;
         IDisposable scope;
         static ILog Logger = LogManager.GetLogger<WindsorObjectBuilder>();
+        bool owned;
     }
 }


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus/issues/4144

If a user passes us in a kernel instance we will not dispose the container instance. We consider that instance externally owned. This is a behavior breaking change. 

I also had to remove the key access since the SettingsHolder automatically disposes settings values that implement `IDisposable`.