### PR TITLE
Externally owned container is no longer disposed

### DIFF
--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.0.0/Exceptions/When_Uow_Begin_and_different_End_throws.cs
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.0.0/Exceptions/When_Uow_Begin_and_different_End_throws.cs
@@ -18,31 +18,13 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new Message())))
-                    .AllowExceptions()
-                    .Done(c => c.ExceptionReceived)
-                    .Run();
+                .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new Message())))
+                .AllowExceptions()
+                .Done(c => c.ExceptionReceived)
+                .Run();
 
             Assert.AreEqual(typeof(BeginException), context.InnerExceptionOneType);
             Assert.AreEqual(typeof(EndException), context.InnerExceptionTwoType);
-
-            
-#if (!DEBUG)
-
-            StackTraceAssert.StartsWith(
-@"at NServiceBus.UnitOfWorkBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ChildContainerBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ProcessingStatisticsBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.Pipeline.PipelineExecutor.Execute[T](BehaviorChain`1 pipelineAction, T context)
-at NServiceBus.Unicast.Transport.TransportReceiver.ProcessMessage(TransportMessage message)
-at NServiceBus.Unicast.Transport.TransportReceiver.TryProcess(TransportMessage message)", context.StackTrace);
-
-            StackTraceAssert.StartsWith(
-string.Format(@"at NServiceBus.AcceptanceTests.Exceptions.When_Uow_Begin_and_different_End_throws.Endpoint.{0}.End(Exception ex)
-at NServiceBus.UnitOfWorkBehavior.AppendEndExceptionsAndRethrow(Exception initialException)", context.TypeName), context.InnerExceptionTwoStackTrace);
-
-#endif
-
         }
 
         public class Context : ScenarioContext
@@ -107,7 +89,7 @@ at NServiceBus.UnitOfWorkBehavior.AppendEndExceptionsAndRethrow(Exception initia
             public class UnitOfWorkThatThrows1 : IManageUnitsOfWork
             {
                 public Context Context { get; set; }
-                
+
                 bool throwAtEnd;
 
                 [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.0.0/Exceptions/When_Uow_Begin_throws.cs
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.0.0/Exceptions/When_Uow_Begin_throws.cs
@@ -24,16 +24,6 @@
                     .Run();
 
             Assert.AreEqual(typeof(BeginException), context.ExceptionType);
-#if (!DEBUG)
-            StackTraceAssert.StartsWith(
-@"at NServiceBus.AcceptanceTests.Exceptions.When_Uow_Begin_throws.Endpoint.UnitOfWorkThatThrowsInBegin.Begin()
-at NServiceBus.UnitOfWorkBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ChildContainerBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ProcessingStatisticsBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.Pipeline.PipelineExecutor.Execute[T](BehaviorChain`1 pipelineAction, T context)
-at NServiceBus.Unicast.Transport.TransportReceiver.ProcessMessage(TransportMessage message)
-at NServiceBus.Unicast.Transport.TransportReceiver.TryProcess(TransportMessage message)", context.StackTrace);
-#endif
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.0.0/Exceptions/When_Uow_End_throws.cs
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.0.0/Exceptions/When_Uow_End_throws.cs
@@ -24,16 +24,6 @@
                     .Run();
 
             Assert.AreEqual(typeof(EndException), context.ExceptionType);
-#if(!DEBUG)
-            StackTraceAssert.StartsWith(
-@"at NServiceBus.AcceptanceTests.Exceptions.When_Uow_End_throws.Endpoint.UnitOfWorkThatThrowsInEnd.End(Exception ex)
-at NServiceBus.UnitOfWorkBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ChildContainerBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ProcessingStatisticsBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.Pipeline.PipelineExecutor.Execute[T](BehaviorChain`1 pipelineAction, T context)
-at NServiceBus.Unicast.Transport.TransportReceiver.ProcessMessage(TransportMessage message)
-at NServiceBus.Unicast.Transport.TransportReceiver.TryProcess(TransportMessage message)", context.StackTrace);
-#endif
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.0.0/Exceptions/When_handler_and_Uow_End_throws.cs
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.0.0/Exceptions/When_handler_and_Uow_End_throws.cs
@@ -25,35 +25,6 @@
 
             Assert.AreEqual(typeof(HandlerException), context.InnerExceptionOneType);
             Assert.AreEqual(typeof(EndException), context.InnerExceptionTwoType);
-
-#if (!DEBUG)
-            StackTraceAssert.StartsWith(
-@"at NServiceBus.UnitOfWorkBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ChildContainerBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ProcessingStatisticsBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.Pipeline.PipelineExecutor.Execute[T](BehaviorChain`1 pipelineAction, T context)
-at NServiceBus.Unicast.Transport.TransportReceiver.ProcessMessage(TransportMessage message)
-at NServiceBus.Unicast.Transport.TransportReceiver.TryProcess(TransportMessage message)", context.StackTrace);
-
-            StackTraceAssert.StartsWith(
-@"at NServiceBus.AcceptanceTests.Exceptions.When_handler_and_Uow_End_throws.Endpoint.Handler.Handle(Message message)
-at NServiceBus.Unicast.MessageHandlerRegistry.Invoke(Object handler, Object message, Dictionary`2 dictionary)
-at NServiceBus.InvokeHandlersBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.SetCurrentMessageBeingHandledBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.LoadHandlersBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ApplyIncomingMessageMutatorsBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ExecuteLogicalMessagesBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.DeserializeLogicalMessagesBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.CallbackInvocationBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ApplyIncomingTransportMessageMutatorsBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.SubscriptionReceiverBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.UnitOfWorkBehavior.Invoke(IncomingContext context, Action next)", context.InnerExceptionOneStackTrace);
-
-            StackTraceAssert.StartsWith(
-string.Format(@"at NServiceBus.AcceptanceTests.Exceptions.When_handler_and_Uow_End_throws.Endpoint.{0}.End(Exception ex)
-at NServiceBus.UnitOfWorkBehavior.AppendEndExceptionsAndRethrow(Exception initialException)", context.TypeName), context.InnerExceptionTwoStackTrace);
-            
-#endif
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.0.0/Exceptions/When_handler_throws.cs
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.0.0/Exceptions/When_handler_throws.cs
@@ -22,26 +22,6 @@
                     .Done(c => c.ExceptionReceived)
                     .Run();
             Assert.AreEqual(typeof(HandlerException), context.ExceptionType);
-#if (!DEBUG)
-      StackTraceAssert.StartsWith(
-@"at NServiceBus.AcceptanceTests.Exceptions.When_handler_throws.Endpoint.Handler.Handle(Message message)
-at NServiceBus.Unicast.MessageHandlerRegistry.Invoke(Object handler, Object message, Dictionary`2 dictionary)
-at NServiceBus.InvokeHandlersBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.SetCurrentMessageBeingHandledBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.LoadHandlersBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ApplyIncomingMessageMutatorsBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ExecuteLogicalMessagesBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.DeserializeLogicalMessagesBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.CallbackInvocationBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ApplyIncomingTransportMessageMutatorsBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.SubscriptionReceiverBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.UnitOfWorkBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ChildContainerBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ProcessingStatisticsBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.Pipeline.PipelineExecutor.Execute[T](BehaviorChain`1 pipelineAction, T context)
-at NServiceBus.Unicast.Transport.TransportReceiver.ProcessMessage(TransportMessage message)
-at NServiceBus.Unicast.Transport.TransportReceiver.TryProcess(TransportMessage message)", context.StackTrace);
-#endif
         }
 
         public class Context : ScenarioContext
@@ -109,5 +89,5 @@ at NServiceBus.Unicast.Transport.TransportReceiver.TryProcess(TransportMessage m
             }
         }
     }
-    
+
 }

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.0.0/Exceptions/When_handler_throws_AggregateException.cs
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.0.0/Exceptions/When_handler_throws_AggregateException.cs
@@ -25,31 +25,6 @@
             Assert.AreEqual(typeof(Exception), context.InnerExceptionType);
             Assert.AreEqual("My Exception", context.ExceptionMessage);
             Assert.AreEqual("My Inner Exception", context.InnerExceptionMessage);
-      
-#if (!DEBUG)
-            StackTraceAssert.StartsWith(
-                @"at NServiceBus.AcceptanceTests.Exceptions.When_handler_throws_AggregateException.Endpoint.Handler.Handle(Message message)
-at NServiceBus.Unicast.MessageHandlerRegistry.Invoke(Object handler, Object message, Dictionary`2 dictionary)
-at NServiceBus.InvokeHandlersBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.SetCurrentMessageBeingHandledBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.LoadHandlersBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ApplyIncomingMessageMutatorsBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ExecuteLogicalMessagesBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.DeserializeLogicalMessagesBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.CallbackInvocationBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ApplyIncomingTransportMessageMutatorsBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.SubscriptionReceiverBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.UnitOfWorkBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ChildContainerBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.ProcessingStatisticsBehavior.Invoke(IncomingContext context, Action next)
-at NServiceBus.Pipeline.PipelineExecutor.Execute[T](BehaviorChain`1 pipelineAction, T context)
-at NServiceBus.Unicast.Transport.TransportReceiver.ProcessMessage(TransportMessage message)
-at NServiceBus.Unicast.Transport.TransportReceiver.TryProcess(TransportMessage message)", context.StackTrace);
-
-            StackTraceAssert.StartsWith(
-                @"at NServiceBus.AcceptanceTests.Exceptions.When_handler_throws_AggregateException.Endpoint.Handler.MethodThatThrows()
-at NServiceBus.AcceptanceTests.Exceptions.When_handler_throws_AggregateException.Endpoint.Handler.Handle(Message message)", context.InnerStackTrace);
-#endif
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/ContainerDecorator.cs
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/ContainerDecorator.cs
@@ -1,0 +1,294 @@
+﻿namespace NServiceBus.CastleWindsor.AcceptanceTests
+{
+    using System;
+    using System.Collections;
+    using Castle.Core;
+    using Castle.MicroKernel;
+    using Castle.MicroKernel.Registration;
+    using Castle.Windsor;
+
+    class ContainerDecorator : IWindsorContainer
+    {
+        IWindsorContainer decorated;
+
+        public ContainerDecorator(IWindsorContainer decorated)
+        {
+            this.decorated = decorated;
+        }
+
+        public void Dispose()
+        {
+            decorated.Dispose();
+            Disposed = true;
+        }
+
+        public bool Disposed { get; private set; }
+
+        public void AddChildContainer(IWindsorContainer childContainer)
+        {
+        }
+
+        public IWindsorContainer AddFacility(IFacility facility)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddFacility<TFacility>() where TFacility : IFacility, new()
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddFacility<TFacility>(Action<TFacility> onCreate) where TFacility : IFacility, new()
+        {
+            return null;
+        }
+
+        public IWindsorContainer GetChildContainer(string name)
+        {
+            return null;
+        }
+
+        public IWindsorContainer Install(params IWindsorInstaller[] installers)
+        {
+            return null;
+        }
+
+        public IWindsorContainer Register(params IRegistration[] registrations)
+        {
+            return null;
+        }
+
+        public void Release(object instance)
+        {
+        }
+
+        public void RemoveChildContainer(IWindsorContainer childContainer)
+        {
+        }
+
+        public object Resolve(string key, Type service)
+        {
+            return null;
+        }
+
+        public object Resolve(Type service)
+        {
+            return null;
+        }
+
+        public object Resolve(Type service, IDictionary arguments)
+        {
+            return null;
+        }
+
+        public object Resolve(Type service, object argumentsAsAnonymousType)
+        {
+            return null;
+        }
+
+        public T Resolve<T>()
+        {
+            return default(T);
+        }
+
+        public T Resolve<T>(IDictionary arguments)
+        {
+            return default(T);
+        }
+
+        public T Resolve<T>(object argumentsAsAnonymousType)
+        {
+            return default(T);
+        }
+
+        public T Resolve<T>(string key)
+        {
+            return default(T);
+        }
+
+        public T Resolve<T>(string key, IDictionary arguments)
+        {
+            return default(T);
+        }
+
+        public T Resolve<T>(string key, object argumentsAsAnonymousType)
+        {
+            return default(T);
+        }
+
+        public object Resolve(string key, Type service, IDictionary arguments)
+        {
+            return null;
+        }
+
+        public object Resolve(string key, Type service, object argumentsAsAnonymousType)
+        {
+            return null;
+        }
+
+        public T[] ResolveAll<T>()
+        {
+            return new T[]
+            {
+            };
+        }
+
+        public Array ResolveAll(Type service)
+        {
+            return null;
+        }
+
+        public Array ResolveAll(Type service, IDictionary arguments)
+        {
+            return null;
+        }
+
+        public Array ResolveAll(Type service, object argumentsAsAnonymousType)
+        {
+            return null;
+        }
+
+        public T[] ResolveAll<T>(IDictionary arguments)
+        {
+            return new T[]
+            {
+            };
+        }
+
+        public T[] ResolveAll<T>(object argumentsAsAnonymousType)
+        {
+            return new T[]
+            {
+            };
+        }
+
+        public IWindsorContainer AddComponent(string key, Type classType)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponent(string key, Type serviceType, Type classType)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponent<T>()
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponent<T>(string key)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponent<I, T>() where T : class
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponent<I, T>(string key) where T : class
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentLifeStyle(string key, Type classType, LifestyleType lifestyle)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentLifeStyle(string key, Type serviceType, Type classType, LifestyleType lifestyle)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentLifeStyle<T>(LifestyleType lifestyle)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentLifeStyle<T>(string key, LifestyleType lifestyle)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentLifeStyle<I, T>(LifestyleType lifestyle) where T : class
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentLifeStyle<I, T>(string key, LifestyleType lifestyle) where T : class
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentProperties<I, T>(IDictionary extendedProperties) where T : class
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentProperties<I, T>(string key, IDictionary extendedProperties) where T : class
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentWithProperties(string key, Type classType, IDictionary extendedProperties)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentWithProperties(string key, Type serviceType, Type classType, IDictionary extendedProperties)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentWithProperties<T>(IDictionary extendedProperties)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddComponentWithProperties<T>(string key, IDictionary extendedProperties)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddFacility(string idInConfiguration, IFacility facility)
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddFacility<TFacility>(string idInConfiguration) where TFacility : IFacility, new()
+        {
+            return null;
+        }
+
+        public IWindsorContainer AddFacility<TFacility>(string idInConfiguration, Action<TFacility> configureFacility) where TFacility : IFacility, new()
+        {
+            return null;
+        }
+
+        public object Resolve(string key, IDictionary arguments)
+        {
+            return null;
+        }
+
+        public object Resolve(string key, object argumentsAsAnonymousType)
+        {
+            return null;
+        }
+
+        public IKernel Kernel { get; }
+        public string Name { get; }
+        public IWindsorContainer Parent { get; set; }
+
+        object IWindsorContainer.this[string key]
+        {
+            get { return null; }
+        }
+
+        object IWindsorContainer.this[Type service]
+        {
+            get { return null; }
+        }
+    }
+}

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\packages\Castle.Core.3.3.1\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Windsor, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{7CC19BCF-C5F3-4681-BEB1-8EFBE67DE459}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NServiceBus.CastleWindsor.AcceptanceTests</RootNamespace>
+    <RootNamespace>NServiceBus.AcceptanceTests</RootNamespace>
     <AssemblyName>NServiceBus.CastleWindsor.AcceptanceTests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -30,6 +30,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Castle.Windsor, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Windsor.3.3.0\lib\net45\Castle.Windsor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting">
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.5.0.0\lib\net45\NServiceBus.AcceptanceTesting.dll</HintPath>
     </Reference>
@@ -167,6 +175,8 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.0.0\Tx\When_sending_within_an_ambient_transaction.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.0.0\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.0.0\Volatile\When_sending_to_non_durable_endpoint.cs" />
+    <Compile Include="ContainerDecorator.cs" />
+    <Compile Include="When_using_externally_owned_container.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/When_using_externally_owned_container.cs
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/When_using_externally_owned_container.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using Castle.Windsor;
+    using NServiceBus;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using CastleWindsor.AcceptanceTests;
+    using NUnit.Framework;
+
+    public class When_using_externally_owned_container : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_shutdown_properly()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsFalse(Endpoint.Decorator.Disposed);
+            Assert.DoesNotThrow(() => Endpoint.Container.Dispose());
+        }
+
+        private class Context : ScenarioContext
+        {
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public static IWindsorContainer Container { get; set; }
+            public static ContainerDecorator Decorator { get; set; }
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    var container = new WindsorContainer();
+                    var decorator = new ContainerDecorator(container);
+
+                    config.UseContainer<WindsorBuilder>(c => c.ExistingContainer(container));
+
+                    Container = container;
+                    Decorator = decorator;
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/packages.config
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="Castle.Windsor" version="3.3.0" targetFramework="net45" />
   <package id="NServiceBus" version="5.0.0" targetFramework="net45" />
   <package id="NServiceBus.AcceptanceTesting" version="5.0.0" targetFramework="net45" />
   <package id="NServiceBus.AcceptanceTests.Sources" version="5.0.0" targetFramework="net45" />

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/packages.config
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="Castle.Core" version="3.3.1" targetFramework="net45" />
   <package id="Castle.Windsor" version="3.3.0" targetFramework="net45" />
   <package id="NServiceBus" version="5.0.0" targetFramework="net45" />
   <package id="NServiceBus.AcceptanceTesting" version="5.0.0" targetFramework="net45" />

--- a/src/NServiceBus.CastleWindsor.Tests/DisposalTests.cs
+++ b/src/NServiceBus.CastleWindsor.Tests/DisposalTests.cs
@@ -1,0 +1,314 @@
+﻿namespace NServiceBus.CastleWindsor.Tests
+{
+    using System;
+    using System.Collections;
+    using Castle.Core;
+    using Castle.MicroKernel;
+    using Castle.MicroKernel.Registration;
+    using Castle.Windsor;
+    using NUnit.Framework;
+    using ObjectBuilder.CastleWindsor;
+
+    [TestFixture]
+    public class DisposalTests
+    {
+        [Test]
+        public void Owned_container_should_be_disposed()
+        {
+            var fakeContainer = new FakeContainer();
+
+            var container = new WindsorObjectBuilder(fakeContainer, true);
+            container.Dispose();
+
+            Assert.True(fakeContainer.Disposed);
+        }
+
+        [Test]
+        public void Externally_owned_container_should_not_be_disposed()
+        {
+            var fakeContainer = new FakeContainer();
+
+            var container = new WindsorObjectBuilder(fakeContainer, false);
+            container.Dispose();
+
+            Assert.False(fakeContainer.Disposed);
+        }
+
+        class FakeContainer : IWindsorContainer
+        {
+            public bool Disposed { get; private set; }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+
+            public void AddChildContainer(IWindsorContainer childContainer)
+            {
+            }
+
+            public IWindsorContainer AddFacility(IFacility facility)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddFacility<TFacility>() where TFacility : IFacility, new()
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddFacility<TFacility>(Action<TFacility> onCreate) where TFacility : IFacility, new()
+            {
+                return null;
+            }
+
+            public IWindsorContainer GetChildContainer(string name)
+            {
+                return null;
+            }
+
+            public IWindsorContainer Install(params IWindsorInstaller[] installers)
+            {
+                return null;
+            }
+
+            public IWindsorContainer Register(params IRegistration[] registrations)
+            {
+                return null;
+            }
+
+            public void Release(object instance)
+            {
+            }
+
+            public void RemoveChildContainer(IWindsorContainer childContainer)
+            {
+            }
+
+            public object Resolve(string key, Type service)
+            {
+                return null;
+            }
+
+            public object Resolve(Type service)
+            {
+                return null;
+            }
+
+            public object Resolve(Type service, IDictionary arguments)
+            {
+                return null;
+            }
+
+            public object Resolve(Type service, object argumentsAsAnonymousType)
+            {
+                return null;
+            }
+
+            public T Resolve<T>()
+            {
+                return default(T);
+            }
+
+            public T Resolve<T>(IDictionary arguments)
+            {
+                return default(T);
+            }
+
+            public T Resolve<T>(object argumentsAsAnonymousType)
+            {
+                return default(T);
+            }
+
+            public T Resolve<T>(string key)
+            {
+                return default(T);
+            }
+
+            public T Resolve<T>(string key, IDictionary arguments)
+            {
+                return default(T);
+            }
+
+            public T Resolve<T>(string key, object argumentsAsAnonymousType)
+            {
+                return default(T);
+            }
+
+            public object Resolve(string key, Type service, IDictionary arguments)
+            {
+                return null;
+            }
+
+            public object Resolve(string key, Type service, object argumentsAsAnonymousType)
+            {
+                return null;
+            }
+
+            public T[] ResolveAll<T>()
+            {
+                return new T[]
+                {
+                };
+            }
+
+            public Array ResolveAll(Type service)
+            {
+                return null;
+            }
+
+            public Array ResolveAll(Type service, IDictionary arguments)
+            {
+                return null;
+            }
+
+            public Array ResolveAll(Type service, object argumentsAsAnonymousType)
+            {
+                return null;
+            }
+
+            public T[] ResolveAll<T>(IDictionary arguments)
+            {
+                return new T[]
+                {
+                };
+            }
+
+            public T[] ResolveAll<T>(object argumentsAsAnonymousType)
+            {
+                return new T[]
+                {
+                };
+            }
+
+            public IWindsorContainer AddComponent(string key, Type classType)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponent(string key, Type serviceType, Type classType)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponent<T>()
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponent<T>(string key)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponent<I, T>() where T : class
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponent<I, T>(string key) where T : class
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentLifeStyle(string key, Type classType, LifestyleType lifestyle)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentLifeStyle(string key, Type serviceType, Type classType, LifestyleType lifestyle)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentLifeStyle<T>(LifestyleType lifestyle)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentLifeStyle<T>(string key, LifestyleType lifestyle)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentLifeStyle<I, T>(LifestyleType lifestyle) where T : class
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentLifeStyle<I, T>(string key, LifestyleType lifestyle) where T : class
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentProperties<I, T>(IDictionary extendedProperties) where T : class
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentProperties<I, T>(string key, IDictionary extendedProperties) where T : class
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentWithProperties(string key, Type classType, IDictionary extendedProperties)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentWithProperties(string key, Type serviceType, Type classType, IDictionary extendedProperties)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentWithProperties<T>(IDictionary extendedProperties)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddComponentWithProperties<T>(string key, IDictionary extendedProperties)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddFacility(string idInConfiguration, IFacility facility)
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddFacility<TFacility>(string idInConfiguration) where TFacility : IFacility, new()
+            {
+                return null;
+            }
+
+            public IWindsorContainer AddFacility<TFacility>(string idInConfiguration, Action<TFacility> configureFacility) where TFacility : IFacility, new()
+            {
+                return null;
+            }
+
+            public object Resolve(string key, IDictionary arguments)
+            {
+                return null;
+            }
+
+            public object Resolve(string key, object argumentsAsAnonymousType)
+            {
+                return null;
+            }
+
+            public IKernel Kernel { get; }
+            public string Name { get; }
+            public IWindsorContainer Parent { get; set; }
+
+            object IWindsorContainer.this[string key]
+            {
+                get { return null; }
+            }
+
+            object IWindsorContainer.this[Type service]
+            {
+                get { return null; }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
+++ b/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
@@ -33,6 +33,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Castle.Windsor, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Windsor.3.3.0\lib\net45\Castle.Windsor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.Core">
       <HintPath>..\packages\NServiceBus.5.0.0\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
@@ -56,6 +64,7 @@
     <Compile Include="App_Packages\NSB.ContainerTests.5.0.0\When_registering_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.5.0.0\When_releasing_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.5.0.0\When_using_nested_containers.cs" />
+    <Compile Include="DisposalTests.cs" />
     <Compile Include="SetUpFixture.cs" />
     <Compile Include="When_base_type_is_registered.cs" />
   </ItemGroup>

--- a/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
+++ b/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\packages\Castle.Core.3.3.1\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Windsor, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">

--- a/src/NServiceBus.CastleWindsor.Tests/packages.config
+++ b/src/NServiceBus.CastleWindsor.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="Castle.Windsor" version="3.3.0" targetFramework="net45" />
   <package id="NServiceBus" version="5.0.0" targetFramework="net45" />
   <package id="NServiceBus.ContainerTests.Sources" version="5.0.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />

--- a/src/NServiceBus.CastleWindsor.Tests/packages.config
+++ b/src/NServiceBus.CastleWindsor.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="Castle.Core" version="3.3.1" targetFramework="net45" />
   <package id="Castle.Windsor" version="3.3.0" targetFramework="net45" />
   <package id="NServiceBus" version="5.0.0" targetFramework="net45" />
   <package id="NServiceBus.ContainerTests.Sources" version="5.0.0" targetFramework="net45" />

--- a/src/NServiceBus.CastleWindsor/WindsorObjectBuilder.cs
+++ b/src/NServiceBus.CastleWindsor/WindsorObjectBuilder.cs
@@ -13,15 +13,20 @@
     class WindsorObjectBuilder : IContainer
     {
         IWindsorContainer container;
+        bool owned;
         IDisposable scope;
         static ILog Logger = LogManager.GetLogger<WindsorObjectBuilder>();
 
         public WindsorObjectBuilder()
-            : this(new WindsorContainer())
+            : this(new WindsorContainer(), true)
         {
         }
 
-        public WindsorObjectBuilder(IWindsorContainer container)
+        public WindsorObjectBuilder(IWindsorContainer container) : this(container, false)
+        {
+        }
+
+        public WindsorObjectBuilder(IWindsorContainer container, bool owned)
         {
             if (container == null)
             {
@@ -29,6 +34,7 @@
             }
 
             this.container = container;
+            this.owned = owned;
         }
 
         public void Dispose()
@@ -44,7 +50,7 @@
                 scope.Dispose();
                 return;
             }
-            if (container != null)
+            if (container != null && owned)
             {
                 container.Dispose();
             }
@@ -72,7 +78,7 @@
             var lifestyle = GetLifestyleTypeFrom(dependencyLifecycle);
             var services = GetAllServiceTypesFor(concreteComponent);
 
-            container.Register(Component.For(services).ImplementedBy(concreteComponent).LifeStyle.Is(lifestyle));            
+            container.Register(Component.For(services).ImplementedBy(concreteComponent).LifeStyle.Is(lifestyle));
         }
 
         void IContainer.Configure<T>(Func<T> componentFactory, DependencyLifecycle dependencyLifecycle)
@@ -163,6 +169,6 @@
                 .Concat(new[] {t});
         }
 
-  
+
     }
 }


### PR DESCRIPTION
backport of https://github.com/Particular/NServiceBus.CastleWindsor/pull/18

Relates to https://github.com/Particular/NServiceBus/issues/4144

## Who's affected

All users providing an externally created container into the endpoint configuration.

## Symptions

If the externally owned container is disposed all instances marked as `IDisposable `that are registered by NServiceBus will be double disposed which can lead to unwanted side effects and endpoints not being able to properly shut down.

(note that this is currently a hotfix branch, not a new minor version)