### PR TITLE
Fix csproj to allow for proper testing

### DIFF
--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
-    <DebugSymbols>True</DebugSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
@@ -10,7 +9,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="[7.0.0-*,8.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-*,8.0)" />
     <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.7.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
     <ProjectReference Include="..\NServiceBus.CastleWindsor\NServiceBus.CastleWindsor.csproj" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
+++ b/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
@@ -4,8 +4,6 @@
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
-    <DebugType>full</DebugType>
-    <DebugSymbols>True</DebugSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
@@ -15,7 +13,7 @@
     <PackageReference Include="NServiceBus" Version="[7.0.0-*,8.0)" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="[7.0.0-*,8.0)" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.7.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
     <ProjectReference Include="..\NServiceBus.CastleWindsor\NServiceBus.CastleWindsor.csproj" />
     <Compile Remove="APIApprovals.cs" />
     <Compile Remove="ApprovalTestConfig.cs" />

--- a/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
+++ b/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
@@ -5,6 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="NServiceBus.ObjectBuilder.CastleWindsor.approved.cs" />

--- a/src/NServiceBus.CastleWindsor/NServiceBus.CastleWindsor.csproj
+++ b/src/NServiceBus.CastleWindsor/NServiceBus.CastleWindsor.csproj
@@ -7,8 +7,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
-    <DebugType>full</DebugType>
-    <DebugSymbols>True</DebugSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
This fixes a couple of things that were left out of the migration process
- `<DebugType>` needs to be removed from all `.csproj` files
- `<DebugSymbols>` needs to be removed from all `.csproj` files
- `NUnit3TestAdapter` nuget needs to be fixed to `3.8.0-alpha1` and *not* wildcarded in all testing projects
- `<CopyLocalLockFileAssemblies>true</...>` needs to be added to all testing `.csproj` files