### PR TITLE
Increase NuGet dependency range to support Castle.Windsor 4.x

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,4 +4,4 @@ branches:
   develop:
     tag: alpha
   releases?[/-]:
-    tag: rc
+    tag: ''

--- a/packaging/nuget/NServiceBus.CastleWindsor.nuspec
+++ b/packaging/nuget/NServiceBus.CastleWindsor.nuspec
@@ -16,7 +16,7 @@
     <tags>$tags$</tags>
     <dependencies>
       <dependency id="NServiceBus" version="[6.0.0, 7.0.0)" />
-      <dependency id="Castle.Windsor" version="[3.3.0, 4.0.0)" />
+      <dependency id="Castle.Windsor" version="[3.3.0, 5.0.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
@@ -31,12 +31,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Castle.Windsor, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Windsor.3.3.0\lib\net45\Castle.Windsor.dll</HintPath>
+    <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Windsor.4.0.0\lib\net45\Castle.Windsor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
@@ -73,6 +73,7 @@
     <Compile Include="When_using_externally_owned_container.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/app.config
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Castle.Windsor" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/packages.config
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
-  <package id="Castle.Windsor" version="3.3.0" targetFramework="net452" />
+  <package id="Castle.Core" version="4.1.1" targetFramework="net452" />
+  <package id="Castle.Windsor" version="4.0.0" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTesting" version="6.0.0" targetFramework="net452" />
   <package id="NUnit" version="3.4.1" targetFramework="net452" />

--- a/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
+++ b/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
@@ -46,12 +46,12 @@
       <HintPath>..\packages\ApprovalUtilities.3.0.11\lib\net45\ApprovalUtilities.Net45.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Castle.Windsor, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Windsor.3.3.0\lib\net45\Castle.Windsor.dll</HintPath>
+    <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Windsor.4.0.0\lib\net45\Castle.Windsor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
@@ -102,6 +102,7 @@
     <Compile Include="When_base_type_is_registered.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/src/NServiceBus.CastleWindsor.Tests/app.config
+++ b/src/NServiceBus.CastleWindsor.Tests/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Castle.Windsor" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/NServiceBus.CastleWindsor.Tests/packages.config
+++ b/src/NServiceBus.CastleWindsor.Tests/packages.config
@@ -3,8 +3,8 @@
   <package id="ApiApprover" version="3.0.1" targetFramework="net452" />
   <package id="ApprovalTests" version="3.0.11" targetFramework="net452" />
   <package id="ApprovalUtilities" version="3.0.11" targetFramework="net452" />
-  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
-  <package id="Castle.Windsor" version="3.3.0" targetFramework="net452" />
+  <package id="Castle.Core" version="4.1.1" targetFramework="net452" />
+  <package id="Castle.Windsor" version="4.0.0" targetFramework="net452" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0" targetFramework="net452" />
   <package id="NServiceBus.ContainerTests.Sources" version="6.0.0" targetFramework="net452" />

--- a/src/NServiceBus.CastleWindsor/NServiceBus.CastleWindsor.csproj
+++ b/src/NServiceBus.CastleWindsor/NServiceBus.CastleWindsor.csproj
@@ -106,11 +106,11 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props'))" />
-    <Error Condition="!Exists('..\packages\NuGetPackager.0.6.0\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.6.0\build\NuGetPackager.targets'))" />
     <Error Condition="!Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.4\build\dotnet\Fody.targets'))" />
     <Error Condition="!Exists('..\packages\GitVersionTask.3.6.3\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.3\build\dotnet\GitVersionTask.targets'))" />
+    <Error Condition="!Exists('..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets'))" />
   </Target>
-  <Import Project="..\packages\NuGetPackager.0.6.0\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.6.0\build\NuGetPackager.targets')" />
   <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" />
   <Import Project="..\packages\GitVersionTask.3.6.3\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.3\build\dotnet\GitVersionTask.targets')" />
+  <Import Project="..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets')" />
 </Project>

--- a/src/NServiceBus.CastleWindsor/packages.config
+++ b/src/NServiceBus.CastleWindsor/packages.config
@@ -6,7 +6,7 @@
   <package id="GitVersionTask" version="3.6.3" targetFramework="net452" developmentDependency="true" />
   <package id="Janitor.Fody" version="1.2.1.0" targetFramework="net452" developmentDependency="true" />
   <package id="NServiceBus" version="6.0.0" targetFramework="net452" />
-  <package id="NuGetPackager" version="0.6.0" targetFramework="net452" developmentDependency="true" />
+  <package id="NuGetPackager" version="0.6.5" targetFramework="net452" developmentDependency="true" />
   <package id="Obsolete.Fody" version="4.1.0" targetFramework="net452" developmentDependency="true" />
   <package id="Particular.CodeRules" version="0.1.1" targetFramework="net452" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
This PR increases the supported dependency range for Castle.Windsor to include 4.x.