### PR TITLE
Update to NServiceBus beta10

### DIFF
--- a/src/NServiceBus.CastleWindsor/NServiceBus.CastleWindsor.csproj
+++ b/src/NServiceBus.CastleWindsor/NServiceBus.CastleWindsor.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="[4.1.1, 5.0.0)" />
     <PackageReference Include="Castle.Windsor" Version="[4.0.0, 5.0.0)" />
-    <PackageReference Include="NServiceBus" Version="[7.0.0-beta0009,8.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[7.0.0-beta0010,8.0.0)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.*" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="*" PrivateAssets="All" />


### PR DESCRIPTION
beta10 contains a breaking change around the `AddStartupDiagnosticsSection` extension method, see https://github.com/Particular/NServiceBus/pull/5039/files and therefore needs to be recompiled against beta10.