### PR TITLE
Remove Castle.Core and bump Castle.Windsor

### DIFF
--- a/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
+++ b/src/NServiceBus.CastleWindsor.AcceptanceTests/NServiceBus.CastleWindsor.AcceptanceTests.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.*" />
     <PackageReference Include="Castle.Windsor" Version="4.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-*" />

--- a/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
+++ b/src/NServiceBus.CastleWindsor.Tests/NServiceBus.CastleWindsor.Tests.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.*" />
     <PackageReference Include="Castle.Windsor" Version="4.*" />
     <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="7.0.0-*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/src/NServiceBus.CastleWindsor/NServiceBus.CastleWindsor.csproj
+++ b/src/NServiceBus.CastleWindsor/NServiceBus.CastleWindsor.csproj
@@ -14,8 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="[4.1.1, 5.0.0)" />
-    <PackageReference Include="Castle.Windsor" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="Castle.Windsor" Version="[4.1.0, 5.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0010,8.0.0)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.*" PrivateAssets="All" />


### PR DESCRIPTION
Castle.Windsor 4.1.0 references a version of Castle.Core that doesn't cause errors for the netstandard target, so this simplifies our package dependencies.