### PR TITLE
Check already registered based on actual type

### DIFF
--- a/src/NServiceBus.CastleWindsor.sln
+++ b/src/NServiceBus.CastleWindsor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.2037
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.CastleWindsor", "NServiceBus.CastleWindsor\NServiceBus.CastleWindsor.csproj", "{9A9A0BD5-AC37-4B90-B90F-FD1C1395FEBD}"
 EndProject
@@ -35,5 +35,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F818F689-26CF-4E5F-86D3-45E52B902B02}
 	EndGlobalSection
 EndGlobal

--- a/src/NServiceBus.CastleWindsor/WindsorObjectBuilder.cs
+++ b/src/NServiceBus.CastleWindsor/WindsorObjectBuilder.cs
@@ -88,7 +88,7 @@
             ThrowIfCalledOnChildContainer();
 
             var lookupTypeFullname = lookupType.FullName;
-            var registration = container.Kernel.GetHandler(lookupTypeFullname);
+            var registration = container.Kernel.GetHandler(lookupType);
 
             if (registration != null)
             {


### PR DESCRIPTION
Fixes #48 

* Adds a test to validate that only 1 instance is returned when an instance is registered for each of it's interfaces
* Changes the "is registered" check to use the actual type instead of the type name